### PR TITLE
이름 표기 방식을 한국식으로 수정

### DIFF
--- a/_includes/partials/get_link.html
+++ b/_includes/partials/get_link.html
@@ -45,10 +45,10 @@
   {%- elsif speaker -%}
     {%- capture modal_title -%}
       {%- if speaker.hide -%}
-        {{ speaker.last_name }} {{ speaker.first_name }} 
+        {{ speaker.last_name }}{{ speaker.first_name }} 
       {%- else -%}
         <a class="text-reset" href="{{ speaker.url | prepend: site.baseurl }}">
-          {{ speaker.last_name }} {{ speaker.first_name }}
+          {{ speaker.last_name }}{{ speaker.first_name }}
         </a>
       {%- endif -%}
     {%- endcapture -%}

--- a/_includes/partials/get_link.html
+++ b/_includes/partials/get_link.html
@@ -45,10 +45,10 @@
   {%- elsif speaker -%}
     {%- capture modal_title -%}
       {%- if speaker.hide -%}
-        {{ speaker.first_name }} {{ speaker.last_name }}
+        {{ speaker.last_name }} {{ speaker.first_name }} 
       {%- else -%}
         <a class="text-reset" href="{{ speaker.url | prepend: site.baseurl }}">
-          {{ speaker.first_name }} {{ speaker.last_name }}
+          {{ speaker.last_name }} {{ speaker.first_name }}
         </a>
       {%- endif -%}
     {%- endcapture -%}

--- a/_includes/partials/get_page_title.html
+++ b/_includes/partials/get_page_title.html
@@ -2,7 +2,7 @@
   {%- if page.layout == 'room' -%}
     {{- page.name -}}
   {%- elsif page.layout == 'speaker' -%}
-    {{ page.last_name -}} {{- page.first_name }}
+    {{ page.last_name -}}{{- page.first_name }}
   {%- elsif page.layout == 'talk' -%}
     {{- page.name -}}
 

--- a/_includes/partials/get_page_title.html
+++ b/_includes/partials/get_page_title.html
@@ -2,7 +2,7 @@
   {%- if page.layout == 'room' -%}
     {{- page.name -}}
   {%- elsif page.layout == 'speaker' -%}
-    {{- page.first_name }} {{ page.last_name -}}
+    {{ page.last_name -}} {{- page.first_name }}
   {%- elsif page.layout == 'talk' -%}
     {{- page.name -}}
 

--- a/_includes/partials/list_speakers.html
+++ b/_includes/partials/list_speakers.html
@@ -1,9 +1,9 @@
 {% for speaker_name in talk.speakers -%}
   {%- assign speaker = site.speakers | where: 'name', speaker_name | first -%}
   {%- if site.conference.speakers.show_firstname -%}
-    {%- assign speaker_short = speaker.first_name | append: ' ' | append: speaker.last_name -%}
+    {%- assign speaker_short = speaker.last_name | append: ' ' | append: speaker.first_name -%}
   {%- else -%}
-    {%- assign speaker_short = speaker.first_name | slice: 0 | append : '. ' | append: speaker.last_name -%}
+    {%- assign speaker_short = speaker.last_name | slice: 0 | append : '. ' | append: speaker.first_name -%}
   {%- endif -%}
 
   {%- if speaker.hide or include.text_only -%}

--- a/_includes/partials/list_speakers.html
+++ b/_includes/partials/list_speakers.html
@@ -1,7 +1,7 @@
 {% for speaker_name in talk.speakers -%}
   {%- assign speaker = site.speakers | where: 'name', speaker_name | first -%}
   {%- if site.conference.speakers.show_firstname -%}
-    {%- assign speaker_short = speaker.last_name | append: ' ' | append: speaker.first_name -%}
+    {%- assign speaker_short = speaker.last_name | append: speaker.first_name -%}
   {%- else -%}
     {%- assign speaker_short = speaker.last_name | slice: 0 | append : '. ' | append: speaker.first_name -%}
   {%- endif -%}

--- a/_layouts/data.html
+++ b/_layouts/data.html
@@ -38,9 +38,9 @@
     {%- for speaker in site.speakers %}
         "{{ speaker.name }}" : {
         {%- if site.conference.speakers.show_firstname %}
-            "name": "{{ speaker.first_name | append: ' ' | append: speaker.last_name }}",
+            "name": "{{ speaker.last_name | append: ' ' | append: speaker.first_name }}",
         {%- else %}
-            "name": "{{ speaker.first_name | slice: 0 | append : '. ' | append: speaker.last_name }}",
+            "name": "{{ speaker.last_name | slice: 0 | append : '. ' | append: speaker.first_name }}",
         {%- endif -%}
         {%- if speaker.hide %}
             "href": ""

--- a/_layouts/data.html
+++ b/_layouts/data.html
@@ -38,7 +38,7 @@
     {%- for speaker in site.speakers %}
         "{{ speaker.name }}" : {
         {%- if site.conference.speakers.show_firstname %}
-            "name": "{{ speaker.last_name | append: ' ' | append: speaker.first_name }}",
+            "name": "{{ speaker.last_name | append: speaker.first_name }}",
         {%- else %}
             "name": "{{ speaker.last_name | slice: 0 | append : '. ' | append: speaker.first_name }}",
         {%- endif -%}

--- a/_layouts/speaker-overview.html
+++ b/_layouts/speaker-overview.html
@@ -30,10 +30,10 @@
 
       <li class="font-weight-light">
         {% if speaker.hide %}
-          {{ speaker.last_name }} {{ speaker.first_name }} 
+          {{ speaker.last_name }}{{ speaker.first_name }} 
         {% else %}
           <a href="{{ speaker.url | prepend: site.baseurl }}">
-            {{ speaker.last_name }} {{ speaker.first_name }}
+            {{ speaker.last_name }}{{ speaker.first_name }}
           </a>
         {% endif %}
       </li>

--- a/_layouts/speaker-overview.html
+++ b/_layouts/speaker-overview.html
@@ -30,10 +30,10 @@
 
       <li class="font-weight-light">
         {% if speaker.hide %}
-          {{ speaker.first_name }} {{ speaker.last_name }}
+          {{ speaker.last_name }} {{ speaker.first_name }} 
         {% else %}
           <a href="{{ speaker.url | prepend: site.baseurl }}">
-            {{ speaker.first_name }} {{ speaker.last_name }}
+            {{ speaker.last_name }} {{ speaker.first_name }}
           </a>
         {% endif %}
       </li>

--- a/_layouts/speaker.html
+++ b/_layouts/speaker.html
@@ -8,7 +8,7 @@
   </p>
 
   <h1 class="font-weight-light mb-3">
-    {{ speaker.first_name }} {{ speaker.last_name }}
+    {{ speaker.last_name }} {{ speaker.first_name }}
   </h1>
 
   {{ content }}

--- a/_layouts/speaker.html
+++ b/_layouts/speaker.html
@@ -8,7 +8,7 @@
   </p>
 
   <h1 class="font-weight-light mb-3">
-    {{ speaker.last_name }} {{ speaker.first_name }}
+    {{ speaker.last_name }}{{ speaker.first_name }}
   </h1>
 
   {{ content }}


### PR DESCRIPTION
한국식 이름 표기 방식으로 수정합니다.

기존: 이름 성
변경: 성 이름

## Before
![image](https://github.com/pythonkr/pyweb-symposium.github.io/assets/76910100/d77341c4-c314-40a5-9417-524407189998)


## After
![image](https://github.com/pythonkr/pyweb-symposium.github.io/assets/76910100/1f5f1c0b-07b4-4abb-8688-1962e8bd084c)
