### PR TITLE
hotfix: 탬플릿내 시간 표시 기능 숨기기

### DIFF
--- a/_layouts/talk.html
+++ b/_layouts/talk.html
@@ -40,11 +40,11 @@
               <span class="live-hide" data-start="{{ timestamp_start }}" data-end="{{ timestamp_end }}">
             {%- endif -%}
 
-            {%- include partials/get_time_pronoun.html -%}
+            <!-- {%- include partials/get_time_pronoun.html -%}
             {%- include partials/get_talk_time.html -%}
             <span class="d-none d-sm-inline">
               {{- time_pronoun -}}
-            </span> {% include partials/show_talk_time.html -%}
+            </span> {% include partials/show_talk_time.html -%} -->
 
             {%- if site.conference.live -%}
               </span>
@@ -56,9 +56,9 @@
               {{- site.data.lang[site.conference.lang].pronoun.in | default: "in" -}}
             </span> {% include partials/show_room.html -%}
 
-            <span class="d-none d-sm-inline ml-1">
+            <!-- <span class="d-none d-sm-inline ml-1">
               {{- site.data.lang[site.conference.lang].pronoun.for | default: "for" -}}
-            </span> {% include partials/show_talk_duration.html -%}
+            </span> {% include partials/show_talk_duration.html -%} -->
 
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
탬플릿내 시간 표시 기능을 숨깁니다.

# Screenshot 

## Before 

![image](https://github.com/pythonkr/pyweb-symposium.github.io/assets/76910100/64df0b44-7a73-46ab-aa18-817eb4a59194)

## After 

![image](https://github.com/pythonkr/pyweb-symposium.github.io/assets/76910100/7f2ba445-f073-462b-8444-8a1419766d62)
